### PR TITLE
build: arm64 cross-compile + publish to ECR

### DIFF
--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -1,0 +1,50 @@
+name: Publish to ECR
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cmd/**/*"
+      - "pkg/**/*"
+      - Dockerfile
+      - makefile
+      - .github/workflows/publish-ecr.yaml
+  workflow_dispatch:
+
+env:
+  AWS_ECR_REPO: "prod/amps"
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  AWS_ECR_ROLE: ${{ secrets.AWS_ECR_ROLE }}
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # arm64 only — the EKS cluster provisions no amd64 nodes. Harbor keeps its own
+      # amd64 builds via release.yaml for the workloads still on the old cluster.
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_REPO }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM golang AS build
+# Build on the native runner arch and cross-compile — Go needs no emulation.
+FROM --platform=$BUILDPLATFORM golang AS build
 
 WORKDIR /app
 
 COPY . .
 
-RUN make build
+ARG TARGETARCH
+
+RUN GOARCH=${TARGETARCH:-amd64} make build
 
 RUN ls -la dist
 

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 BINARY_NAME=amps
 DIST_DIR=./dist/
+GOARCH ?= amd64
 
 
 dev:
@@ -11,7 +12,7 @@ server:
 	go run ./hack/webserver.go
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(DIST_DIR)$(BINARY_NAME) ./cmd/amps/amps.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) $(GOBUILD) -o $(DIST_DIR)$(BINARY_NAME) ./cmd/amps/amps.go
 
 runTests:
 	go test ./test/... -v --timeout 20s


### PR DESCRIPTION
## Why

`makefile:build` hardcoded `GOARCH=amd64`, so every published `amps` image is amd64-only. The hotellistat EKS cluster (`prod-cluster`, account `658483440532`) provisions **arm64 nodes only** — verified: both nodes report `arm64`.

This blocks the `aris-engine` EKS migration: the engine pod runs `amps` as a sidecar, and the sidecar is the pod's only readiness gate. Building with `--platform linux/arm64` alone does **not** fix it — `make` would still emit an amd64 binary into an arm64 base image (the same trap found in `derivation-engine`'s Makefile).

## What

- `makefile` — `GOARCH ?= amd64`. Existing Harbor workflows are unaffected: they call plain `make build` and still get amd64.
- `Dockerfile` — builds on `$BUILDPLATFORM` and passes `$TARGETARCH` to make, so Go cross-compiles natively rather than running the toolchain under QEMU.
- `.github/workflows/publish-ecr.yaml` (new) — pushes `linux/arm64` to `prod/amps` via GitHub OIDC, tagged by commit SHA. No floating tag: the EKS charts must pin the sidecar image.

Harbor publishing (`release.yaml`, `release-tag.yaml`) is untouched — this is additive, matching the migration's "Harbor workflows stay untouched" decision.

## Verification

Both platforms built locally with buildx:

| Build | Result |
|---|---|
| `--platform linux/arm64` | image reports `arm64 linux`, binary executes |
| `--platform linux/amd64` | image reports `amd64 linux` (unchanged behaviour) |

`actionlint` passes on the new workflow.

## Before this can merge

The ECR repository `prod/amps` must exist — it is added in the companion `infrastructure-as-code` PR. Merging this first means the first run fails with `repository does not exist`; re-run via `workflow_dispatch` after the tofu apply.

Requires repo secrets `AWS_REGION`, `AWS_ACCOUNT_ID`, `AWS_ECR_ROLE` (same names the other hotellistat repos use). The OIDC role `GitHubActions-ECR-Role` already trusts `repo:hotellistat/*:*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VVGWgzfKJj6cqDvGf3jHK